### PR TITLE
RFC6743 and 6742 set the size of the preference and lifetime fields

### DIFF
--- a/include/net/ilnp6.h
+++ b/include/net/ilnp6.h
@@ -147,8 +147,8 @@ struct ilcc_table {
 /*Structure for LU message*/
 struct lu_data {
       uint64_t		l64;
-      uint32_t		prec;
-      uint32_t		lifetime;
+      uint16_t		prec;
+      uint16_t		lifetime;
 
 };
 


### PR DESCRIPTION
to 16 bits. Trying to do some interop testing, I discovered they
are being sent as 32bits. Its probably easier to change your
implementation than the RFC at this point....

Signed-off-by: Rick Payne <rickp@rossfell.co.uk>