### PR TITLE
Locator Update message size issues

### DIFF
--- a/include/net/ilnp6.h
+++ b/include/net/ilnp6.h
@@ -147,8 +147,8 @@ struct ilcc_table {
 /*Structure for LU message*/
 struct lu_data {
       uint64_t		l64;
-      uint32_t		prec;
-      uint32_t		lifetime;
+      uint16_t		prec;
+      uint16_t		lifetime;
 
 };
 

--- a/include/net/ilnp6.h
+++ b/include/net/ilnp6.h
@@ -162,8 +162,8 @@ struct lu_msg {
       __be16		reserved;
       /* Data */
       uint64_t		l64;
-      uint32_t		prec;
-      uint32_t		lifetime;
+      uint16_t		prec;
+      uint16_t		lifetime;
 };
 
 /*Structure of LU message that has been sent and still wait for LU-ACK


### PR DESCRIPTION
The RFC specifies 16 bits for both the Preference and the Lifetime. The linux implementation uses u32. This changes both of those, but I've done no further testing.